### PR TITLE
Fix MD001 heading increment violation in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,11 +7,11 @@ assignees: ''
 
 ---
 
-### Describe the bug
+## Describe the bug
 
 A clear and concise description of what the bug is.
 
-### To Reproduce
+## To Reproduce
 
 Steps to reproduce the behaviour:
 
@@ -20,15 +20,15 @@ Steps to reproduce the behaviour:
 3. Scroll down to '....'
 4. See error
 
-### Expected behaviour
+## Expected behaviour
 
 A clear and concise description of what you expected to happen.
 
-### Screenshots
+## Screenshots
 
 If applicable, add screenshots to help explain your problem.
 
-### Desktop
+## Desktop
 
 Please complete the following information:
 
@@ -36,7 +36,7 @@ Please complete the following information:
 * Browser [e.g. chrome, safari]
 * Version [e.g. 22]
 
-### Smartphone
+## Smartphone
 
 Please complete the following information:
 
@@ -45,6 +45,6 @@ Please complete the following information:
 * Browser [e.g. stock browser, safari]
 * Version [e.g. 22]
 
-### Additional context
+## Additional context
 
 Add any other context about the problem here.


### PR DESCRIPTION
## Summary

- Demoted `###` (h3) headings to `##` (h2) in `bug_report.md` to fix a MD001 markdownlint violation
- All other markdown files pass linting with no issues

## Test plan

- [x] `markdownlint-cli` run across all `.md` files — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)