### PR TITLE
Replace GitGuardian ggshield with gitleaks for secret scanning

### DIFF
--- a/.github/workflows/reusable_secret_scan.yml
+++ b/.github/workflows/reusable_secret_scan.yml
@@ -1,14 +1,10 @@
 name: "Reusable: Secret Scan"
 on:
   workflow_call:
-    secrets:
-      GITGUARDIAN_API_KEY:
-        description: GitGuardian API key for secret scanning
-        required: true
 
 jobs:
   secret-scan:
-    name: GitGuardian scan
+    name: Gitleaks scan
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,10 +15,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@v1
+      - name: Gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
-          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
-          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/secret_scan.yml
+++ b/.github/workflows/secret_scan.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   secret-scan:
-    name: GitGuardian scan
+    name: Gitleaks scan
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -19,10 +19,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: GitGuardian scan
-        uses: GitGuardian/ggshield-action@v1
+      - name: Gitleaks scan
+        uses: gitleaks/gitleaks-action@v2
         env:
-          GITHUB_PUSH_BEFORE_SHA: ${{ github.event.before }}
-          GITHUB_PUSH_BASE_SHA: ${{ github.event.base }}
-          GITHUB_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          GITGUARDIAN_API_KEY: ${{ secrets.GITGUARDIAN_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,3 @@
-ci:
-    skip: [ggshield]
-
 repos:
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
@@ -9,11 +6,11 @@ repos:
       - id: markdownlint
         name: markdown linting
 
-  - repo: https://github.com/gitguardian/ggshield
-    rev: v1.38.1
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.24.3
     hooks:
-      - id: ggshield
-        name: gitguardian scanning
+      - id: gitleaks
+        name: secret scanning
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "cSpell.words": [
-        "ggshield",
-        "gitguardian",
+        "gitleaks",
         "markdownlint"
-    ]
+    ],
+    "kiroAgent.configureMCP": "Disabled"
 }


### PR DESCRIPTION
## Summary

- Replace `ggshield` pre-commit hook with `gitleaks` v8.24.3
- Remove the `ci: skip` block (no longer needed — gitleaks requires no external credentials)
- Update `secret_scan.yml` workflow to use `gitleaks/gitleaks-action@v2`
- Update `reusable_secret_scan.yml` to use gitleaks and remove the `GITGUARDIAN_API_KEY` secrets input
- Update VS Code spell-check dictionary

## Motivation

GitGuardian requires an external account and `GITGUARDIAN_API_KEY` secret. Gitleaks is fully open source, credential-free, and uses `GITHUB_TOKEN` — aligning with GitHub-native tooling and removing the external dependency.

## Test plan

- [ ] Pre-commit hook runs locally without credentials
- [ ] `secret_scan.yml` workflow passes on PR with only `GITHUB_TOKEN`
- [ ] No `GITGUARDIAN_API_KEY` secret required in any repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)