### PR TITLE
Pin DCO check action to full commit SHA

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -18,6 +18,6 @@ jobs:
           fetch-depth: 0
 
       - name: Check DCO
-        uses: christophebedard/dco-check@v0.3.0
+        uses: christophebedard/dco-check@547f0d10eb3d42a8326ed99b12147fdc20e4a501 # v0.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Pin `christophebedard/dco-check` from `@v0.3.0` to `@547f0d10eb3d42a8326ed99b12147fdc20e4a501` with the tag retained as an inline comment for readability

## Motivation

Mutable tags (e.g. `@v0.3.0`) can be silently moved by the upstream maintainer to point to different — potentially malicious — code. Pinning to a full SHA guarantees the exact code that runs in CI never changes without an explicit update to this file.

## Test plan

- [ ] DCO check workflow runs successfully on a PR with signed commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)