### PR TITLE
Add CLAUDE.md to guide Claude Code

### DIFF
--- a/.github/workflows/auto_approve_bots.yml
+++ b/.github/workflows/auto_approve_bots.yml
@@ -2,6 +2,9 @@ name: Auto approve
 
 on: pull_request
 
+permissions:
+  contents: read
+
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
@@ -9,6 +12,11 @@ jobs:
       pull-requests: write
     if: contains(fromJson('["dependabot[bot]", "pre-commit-ci[bot]", "jf-delineate"]'), github.actor)
     steps:
-      - uses: hmarr/auto-approve-action@v3
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: hmarr/auto-approve-action@7d0ab8fdbb906da8a6297d373561d5ccb137d98f # v3
         with:
           review-message: "Auto approved automated PR"

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+# Dependency Review Action
+#
+# This Action will scan dependency manifest files that change as part of a Pull Request,
+# surfacing known-vulnerable versions of the packages declared or updated in the PR.
+# Once installed, if the workflow run is marked as required,
+# PRs introducing known-vulnerable packages will be blocked from merging.
+#
+# Source repository: https://github.com/actions/dependency-review-action
+name: 'Dependency Review'
+on: [pull_request]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - name: 'Checkout Repository'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: 'Dependency Review'
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0

--- a/.github/workflows/label_sync.yml
+++ b/.github/workflows/label_sync.yml
@@ -7,6 +7,9 @@ on:
       - .github/labels.yml
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   label-sync:
     name: Sync labels across org
@@ -15,11 +18,16 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Sync labels
-        uses: EndBug/label-sync@v2
+        uses: EndBug/label-sync@52074158190acb45f3077f9099fea818aa43f97a # v2.3.3
         with:
           config-file: .github/labels.yml
           delete-other-labels: false

--- a/.github/workflows/release_please.yml
+++ b/.github/workflows/release_please.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master
 
+permissions:
+  contents: read
+
 jobs:
   release-please:
     name: Release
@@ -13,6 +16,11 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: googleapis/release-please-action@v4
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # v4.4.0
         with:
           release-type: simple

--- a/.github/workflows/reusable_markdown_lint.yml
+++ b/.github/workflows/reusable_markdown_lint.yml
@@ -8,6 +8,9 @@ on:
         default: .markdownlint.json
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint:
     name: Markdown lint
@@ -16,11 +19,16 @@ jobs:
       contents: read
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Lint markdown
-        uses: DavidAnson/markdownlint-cli2-action@v17
+        uses: DavidAnson/markdownlint-cli2-action@db43aef879112c3119a410d69f66701e0d530809 # v17.0.0
         with:
           config: ${{ inputs.config-path }}
           globs: "**/*.md"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -20,19 +20,24 @@ jobs:
       actions: read
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2.4.0
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
         with:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
 
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3.32.6
         with:
           sarif_file: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,9 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   stale:
     name: Mark and close stale items
@@ -13,7 +16,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/stale@v9
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
         with:
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had

--- a/.github/workflows/tfsec_scan.yml
+++ b/.github/workflows/tfsec_scan.yml
@@ -4,6 +4,9 @@ on:
     types: [opened, reopened]
   schedule:
     - cron: '0 0 * * *'
+permissions:
+  contents: read
+
 jobs:
   tfsec:
     name: tfsec
@@ -13,14 +16,19 @@ jobs:
       security-events: write
 
     steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
       - name: Clone repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: tfsec
-        uses: aquasecurity/tfsec-action@v1.0.0
+        uses: aquasecurity/tfsec-action@a73ebc46fba54691e25cbe901656e7b205fb9bf2 # v1.0.0
         with:
           sarif_file: tfsec.sarif
       - name: Upload SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3.32.6
         if: always()
         with:
           sarif_file: tfsec.sarif

--- a/.github/workflows/tfsec_scan.yml
+++ b/.github/workflows/tfsec_scan.yml
@@ -29,6 +29,6 @@ jobs:
           sarif_file: tfsec.sarif
       - name: Upload SARIF results
         uses: github/codeql-action/upload-sarif@820e3160e279568db735cee8ed8f8e77a6da7818 # v3.32.6
-        if: always()
+        if: always() && hashFiles('tfsec.sarif') != ''
         with:
           sarif_file: tfsec.sarif

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -5,6 +5,9 @@ on:
   issues:
     types: [opened]
 
+permissions:
+  contents: read
+
 jobs:
   welcome:
     name: Welcome first-time contributors
@@ -14,7 +17,12 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/first-interaction@v1
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@58077d3c7e43986b6b15fba718e8ea69e387dfcc # v2.15.1
+        with:
+          egress-policy: audit
+
+      - uses: actions/first-interaction@3c71ce730280171fd1cfb57c00c774f8998586f7 # v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           issue-message: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
         name: check yaml
       - id: check-json
         name: check json
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.16.3
+    hooks:
+      - id: gitleaks

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,4 +62,3 @@ All workflows use **StepSecurity runner hardening** (`step-security/harden-runne
 ## Pushes
 
 All pushes should be rebased before besing pushed to ensure they are signed
-

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Purpose
+
+This is the delineate.io organization `.github` repository. It provides:
+- **Default community health files** applied automatically to all org repos (CODE_OF_CONDUCT.md, CONTRIBUTING.md, SECURITY.md, LICENSE, PULL_REQUEST_TEMPLATE.md, issue templates)
+- **Shared/reusable GitHub Actions workflows** (e.g., `reusable_markdown_lint.yml`)
+- **Organization-wide automation** (label sync, release management, security scanning, bot auto-approval)
+
+## Common Commands
+
+### Pre-commit
+
+```bash
+# Install hooks
+pre-commit install
+
+# Run all hooks against all files
+pre-commit run --all-files
+
+# Run a specific hook
+pre-commit run markdownlint --all-files
+pre-commit run gitleaks --all-files
+```
+
+### Markdown Linting
+
+Markdown rules are configured in `.markdownlint.json`. Disabled: MD004, MD013, MD033, MD041.
+
+## Workflow Architecture
+
+All workflows use **StepSecurity runner hardening** (`step-security/harden-runner`) with egress policy auditing. Actions are pinned to full commit SHAs for security.
+
+### Key Workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `dco.yml` | PR | Validates DCO sign-off on all commits |
+| `dependency-review.yml` | PR | Blocks PRs with vulnerable dependencies |
+| `tfsec_scan.yml` | PR + daily | Terraform security scanning → SARIF upload |
+| `scorecard.yml` | master push + weekly | OpenSSF security posture analysis |
+| `label_sync.yml` | `labels.yml` push to master | Syncs canonical labels org-wide via `LABEL_SYNC_TOKEN` |
+| `release_please.yml` | master push | Automated semantic versioning and releases |
+| `auto_approve_bots.yml` | PR | Auto-approves dependabot, pre-commit-ci, jf-delineate PRs |
+| `stale.yml` | daily | Closes stale issues (60d) and PRs (30d) |
+| `welcome.yml` | issue/PR open | Welcomes first-time contributors |
+| `reusable_markdown_lint.yml` | `workflow_call` | Reusable markdown lint — called from other org repos |
+
+### Secrets Required
+
+- `LABEL_SYNC_TOKEN` — Cross-org GitHub token for label synchronization
+
+## Conventions
+
+- **Indentation**: 2 spaces universally (enforced by `.editorconfig`)
+- **Line endings**: LF
+- **Label definitions**: Canonical set maintained in `.github/labels.yml` (24 labels across type/status/priority/meta)
+- **Dependabot**: Configured for weekly GitHub Actions updates, max 5 open PRs
+
+## Pushes
+
+All pushes should be rebased before besing pushed to ensure they are signed
+


### PR DESCRIPTION
## Summary

- Adds `CLAUDE.md` to provide Claude Code with context about this repository's purpose, workflows, and conventions

## Test plan

- [ ] Verify CLAUDE.md renders correctly on GitHub
- [ ] Confirm pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)